### PR TITLE
added possibility to provide additional connection options. Fixes bug when connecting to IIS with HTTPS

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -36,7 +36,7 @@ exports.Client = function (options){
 
 		return result;
 	  },
-	  createConnectOptions:function(connectURL){
+	  createConnectOptions:function(connectURL, connOptions){
 	  		debug("connect URL = ", connectURL)
 			var url = urlParser.parse(connectURL),
 				path,
@@ -67,6 +67,14 @@ exports.Client = function (options){
 					headers: this.createProxyHeaders()
 				    };
 			}
+
+            if(connOptions){
+                if(typeof connOptions === 'object'){
+                    for(var option in connOptions){
+                        result[option] = connOptions[option];
+                    }
+                }
+            }
 
 			return result;
 		},
@@ -113,7 +121,7 @@ exports.Client = function (options){
 		},
 		connect : function(method, url, args, callback){
 			// configure connect options based on url parameter parse
-			var options = this.createConnectOptions(this.parsePathParameters(args,url));
+			var options = this.createConnectOptions(this.parsePathParameters(args,url), args.connOptions);
 			options.method = method;
 			debug("options pre connect",options);
 			debug("args = ", args);


### PR DESCRIPTION
Now it is possible to provide additional connection options to the
client.

For example it was not possible to connect to SSL-enabled IIS servers
due to not supported encryption. (eg see https://github.com/joyent/node/issues/5360)

use the following args when connecting to IIS with SSL:

args = {
path: {"type": "Events", scope: "Main"},
parameters: {},
headers: {"x-bwin-accessId": ""},
connOptions:
{
secureOptions: constants.SSL_OP_NO_TLSv1_2,
ciphers:
'ECDHE-RSA-AES256-SHA:AES256-SHA:RC4-SHA:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM',
honorCipherOrder: true
}
}
