### PR TITLE
improve json content type detection

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -244,7 +244,7 @@ exports.Client = function (options){
 
 	var ConnectManager = {
 		"xmlctype":["application/xml","application/xml;charset=utf-8"],
-		"jsonctype":["application/json","application/json;charset=utf-8"],
+		"jsonctype":"application/json",
 		"isXML":function(content){
 			var result = false;
 			for (var i=0; i<this.xmlctype.length;i++){
@@ -255,13 +255,7 @@ exports.Client = function (options){
 			return result;
 		},
 		"isJSON":function(content){
-			var result = false;
-			for (var i=0; i<this.jsonctype.length;i++){
-				result = this.jsonctype[i] === content;
-				if (result) break;
-			}
-			
-			return result;
+			return content.match(new RegExp(this.jsonctype, 'i'));
 		},
 		"proxy":function(options, callback){
 


### PR DESCRIPTION
Hi,

I am  using your package and think it is great. What I always wondered about is why it wasn't able to automatically parse a json response until I read the code. I replaced the json checker with a regular expression. I think that the same could be done for the xml detection as well.
