### PR TITLE
Registered methods errorHandling

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -188,7 +188,7 @@ exports.Client = function (options){
 							completeURL = url.concat(Util.encodeQueryFromArgs(args.parameters));
 						}
 					}
-					httpMethod(completeURL, args , callback);
+					return httpMethod(completeURL, args , callback);
 				};
 	};
 


### PR DESCRIPTION
Hi, in your documentation it says that error handling should work in the following way:

```
var req2=client.methods.jsonMethod(function(data,response){
    // parsed response body as js object
    console.log(data);
    // raw response
    console.log(response);
});

// handling specific req2 errors
req2.on('error',function(err){
    console.log('something went wrong on req2!!', err.request.options);
});
```

But in this case, `req2` is undefined. 

This was all caused by a missing return. 
