### PR TITLE
Issue with isXML/isJson on ConnectManager

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -249,8 +249,8 @@ exports.Client = function (options){
 
 
 	var ConnectManager = {
-		"xmlctype":["application/xml","application/xml;charset=utf-8"],
-		"jsonctype":["application/json","application/json;charset=utf-8"],
+		"xmlctype":["/xml"],
+		"jsonctype":["/json"],
 		"isXML":function(content){
 			var result = false;
 			for (var i=0; i<this.xmlctype.length;i++){


### PR DESCRIPTION
The method isXML on ConnectManager doesn't works properly

I'm having issues with a request to the following url:

http://services.tvrage.com/feeds/search.php?show=orange%20black

On this method it is checking two fixed content types:

"application/xml","application/xml;charset=utf-8"

but the response of this url is returning: "text/xml; charset=UTF-8"
which doesn't match with any of them.
