### PR TITLE
fix conditional bug

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -11,7 +11,7 @@ exports.Client = function (options){
 
 	self.options = options || {},
 	self.useProxy = (self.options.proxy || false)?true:false,
-	self.useProxyTunnel = self.options.proxy.tunnel===undefined?true:self.options.proxy.tunnel,
+    self.useProxyTunnel = (!self.useProxy || self.options.proxy.tunnel===undefined)?false:self.options.proxy.tunnel,
 	self.proxy = self.options.proxy,
 	self.connection = self.options.connection || {},
 	self.mimetypes = self.options.mimetypes || {};


### PR DESCRIPTION
I use node 0.10.1, 
node_rest_client.js will report error at line 14: 
`self.useProxyTunnel = (!self.useProxy || self.options.proxy.tunnel===undefined)?false:self.options.proxy.tunnel,`
