### PR TITLE
Fix errors where there are no Content-Encoding headers in the response

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -310,12 +310,12 @@ exports.Client = function (options){
 			debug("content-type: ", content);
 			debug("content-encoding: ",encoding);
 
-			if(encoding.indexOf("gzip") >= 0){
+			if(encoding !== undefined && encoding.indexOf("gzip") >= 0){
 				debug("gunzip");
 				zlib.gunzip(Buffer.concat(buffer),function(er,gunzipped){
 					self.handleResponse(res,gunzipped,callback);
 				});
-			}else if(encoding.indexOf("deflate") >= 0){
+			}else if(encoding !== undefined && encoding.indexOf("deflate") >= 0){
 				debug("inflate");
 				zlib.inflate(Buffer.concat(buffer),function(er,inflated){
 					self.handleResponse(res,inflated,callback);


### PR DESCRIPTION
Content-Encoding is a not a required header in the spec, but the recent changes introduced a regression where if no Content-Encoding header is set, an exception occurs. This adds validation to the response.
