### PR TITLE
fixes an undefined error when encoding not specified

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -310,12 +310,12 @@ exports.Client = function (options){
 			debug("content-type: ", content);
 			debug("content-encoding: ",encoding);
 
-			if(encoding.indexOf("gzip") >= 0){
+			if(encoding && encoding.indexOf("gzip") >= 0){
 				debug("gunzip");
 				zlib.gunzip(Buffer.concat(buffer),function(er,gunzipped){
 					self.handleResponse(res,gunzipped,callback);
 				});
-			}else if(encoding.indexOf("deflate") >= 0){
+			}else if(encoding && encoding.indexOf("deflate") >= 0){
 				debug("inflate");
 				zlib.inflate(Buffer.concat(buffer),function(er,inflated){
 					self.handleResponse(res,inflated,callback);


### PR DESCRIPTION
I was getting an error when encoding was undefined.  I didn't see any test cases that covered anything so I didn't add any.
