### PR TITLE
Modified isXML and isJSON to perform case insensitive content-type check

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -18,7 +18,7 @@ exports.Client = function (options){
 	self.mimetypes = self.options.mimetypes || {};
 
 	this.methods={};
-	
+
 
 	// Client Request to be passed to ConnectManager and returned
 	// for each REST method invocation
@@ -27,7 +27,7 @@ exports.Client = function (options){
 	};
 
 	util.inherits(ClientRequest, events.EventEmitter);
-	
+
 
 	var Util = {
 
@@ -83,7 +83,7 @@ exports.Client = function (options){
 					method: self.useProxyTunnel?'CONNECT':connectMethod,//if proxy tunnel use 'CONNECT' method, else get method from request,
 					path: self.useProxyTunnel?this.createProxyPath(url):connectURL, // if proxy tunnel set proxy path else get request path,
 					headers: this.createProxyHeaders(url) // createProxyHeaders add correct headers depending of proxy connection type
-				    };				    
+				    };
 			}
 
             if(self.connection && typeof self.connection === 'object'){
@@ -126,7 +126,7 @@ exports.Client = function (options){
 				var keyValue = key + "=" + encodeURIComponent(args[key]);
 				if (counter > 1) keyValue = '&'.concat(keyValue);
 				result = result.concat(keyValue);
-				
+
 				counter++;
 			}
 
@@ -139,9 +139,9 @@ exports.Client = function (options){
 			for (var placeholder in args.path){
 				var regex = new RegExp("\\$\\{" + placeholder + "\\}","i");
 				result = result.replace(regex,args.path[placeholder]);
-				
+
 			}
-			
+
 			return result;
 
 		},
@@ -172,10 +172,10 @@ exports.Client = function (options){
 		          options.path +=(options.path.charAt(url.length-1) === '?'?"?":"");
 		          options.path = options.path.concat(Util.encodeQueryFromArgs(args.parameters));
 		          debug("options.path after request parameters = ", options.path);
-		        }				
-				
+		        }
+
 			}
-			
+
 			debug("FINAL SELF object  ====>", self);
 
 			if (self.useProxy && self.useProxyTunnel){
@@ -198,7 +198,7 @@ exports.Client = function (options){
 	},
 	Method = function(url, method){
 		var httpMethod = self[method.toLowerCase()];
-			
+
 		    return  function(args,callback){
 					var completeURL = url;
 					//no args
@@ -224,8 +224,8 @@ exports.Client = function (options){
 
 
 	this.get = function(url, args, callback){
-		var clientRequest = new ClientRequest();			
-		Util.connect('GET', url, args, callback, clientRequest);		
+		var clientRequest = new ClientRequest();
+		Util.connect('GET', url, args, callback, clientRequest);
 		return clientRequest;
 	};
 
@@ -268,7 +268,7 @@ exports.Client = function (options){
 	ConnectManager.on('error',function(err){
 		self.emit('error',err);
 	});
-	
+
 	// merge mime types with connect manager
 	Util.mergeMimeTypes(self.mimetypes);
 	debug("ConnectManager", ConnectManager);
@@ -282,31 +282,31 @@ exports.Client = function (options){
 		"isXML":function(content){
 			var result = false;
 			for (var i=0; i<this.xmlctype.length;i++){
-				result = this.xmlctype[i] === content;
+				result = this.xmlctype[i].toLowerCase() === content.toLowerCase();
 				if (result) break;
 			}
-			
+
 			return result;
 		},
 		"isJSON":function(content){
 			var result = false;
 			for (var i=0; i<this.jsonctype.length;i++){
-				result = this.jsonctype[i] === content;
+				result = this.jsonctype[i].toLowerCase() === content.toLowerCase();
 				if (result) break;
 			}
-			
+
 			return result;
 		},
 		"isValidData":function(data){
 			return data != undefined && (data.length != undefined && data.length > 0);
 		},
 		"handleEnd":function(res,buffer,callback){
-			
+
 			self = this;
 
 			var content = res.headers["content-type"];
 			var encoding = res.headers["content-encoding"];
-			
+
 			debug("content-type: ", content);
 			debug("content-encoding: ",encoding);
 
@@ -342,12 +342,12 @@ exports.Client = function (options){
 		"proxy":function(options, callback){
 
 			debug("proxy options",options.proxy);
-			
+
 			// creare a new proxy tunnel, and use to connect to API URL
 			var proxyTunnel = http.request(options.proxy),
 				self = this;
-		
-			
+
+
 			proxyTunnel.on('connect',function(res, socket, head){
 				debug("proxy connected",socket);
 
@@ -357,7 +357,7 @@ exports.Client = function (options){
 				var buffer=[],
 					protocol = (options.protocol =="http")?http:https,
 					clientRequest = options.clientRequest;
-				
+
 				//remove "protocol" and "clientRequest" option from options, cos is not allowed by http/hppts node objects
 				delete options.protocol;
 				delete options.clientRequest;
@@ -372,7 +372,7 @@ exports.Client = function (options){
 						});
 
 						res.on('end',function(){
-							self.handleEnd(res,buffer,callback);							
+							self.handleEnd(res,buffer,callback);
 						});
 
 
@@ -390,7 +390,7 @@ exports.Client = function (options){
 							}
 						});
 				});
-				
+
 				// write POST/PUT data to request body;
 				if(options.data) request.write(typeof options.data === 'object'?JSON.stringify(options.data):options.data);
 
@@ -400,7 +400,7 @@ exports.Client = function (options){
 					if (clientRequest !== undefined && typeof clientRequest === 'object'){
 						// add request as property of error
 						err.request = clientRequest;
-						
+
 						// request error handler
 						clientRequest.emit('error',err);
 					}else{
@@ -418,15 +418,15 @@ exports.Client = function (options){
 			});
 
 			proxyTunnel.end();
-			
+
 		},
 		"normal":function(options, callback){
 
 				var buffer = [],
 				protocol = (options.protocol === "http")?http:https,
-				clientRequest = options.clientRequest,	
+				clientRequest = options.clientRequest,
 						self = this;
-				
+
 				//remove "protocol" and "clientRequest" option from options, cos is not allowed by http/hppts node objects
 				delete options.protocol;
 				delete options.clientRequest;
@@ -461,7 +461,7 @@ exports.Client = function (options){
 							}
 						});
 				});
-			 
+
 				// handle request errors and handle them by request or general error handler
 				request.on('error',function(err){
 					debug('request error', clientRequest);
@@ -482,7 +482,7 @@ exports.Client = function (options){
 			if(options.data) request.write(typeof options.data === 'object'?JSON.stringify(options.data):options.data);
 
 			 request.end();
-			 
+
 		}
 	};
 


### PR DESCRIPTION
Added .toLowerCase() to the isJSON and isXML methods to perform case insensitive content-type checking.

It seems as though the latest version had a number of lines with trailing spaces.  My Sublime Text has a setting to trim trailing spaces on save.  Sorry for all the unecssary lines in the patch.  The only changes to review are lines 285 and 294.
