### PR TITLE
Fix global leak of events and zlib

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -2,8 +2,8 @@ var http = require('http'),
 	https = require('https'),
 	parseString = require('xml2js').parseString,
 	urlParser = require('url'),
-	util = require("util");
-	events = require("events");
+	util = require("util"),
+	events = require("events"),
 	zlib = require("zlib");
 
 


### PR DESCRIPTION
The terminating semicolons on the prior lines cause the events and
zlib variable to be global variables. Which is not exactly what was
intended here.
