### PR TITLE
Cast chunk to Buffer as required by Buffer.concat

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -452,7 +452,7 @@ exports.Client = function (options){
 
 						// concurrent data chunk handler
 						res.on('data',function(chunk){
-							buffer.push(chunk);
+							buffer.push(new Buffer(chunk));
 						});
 
 						res.on('end',function(){
@@ -538,7 +538,7 @@ exports.Client = function (options){
 
 						// concurrent data chunk handler
 						res.on('data',function(chunk){
-							buffer.push(chunk);
+							buffer.push(new Buffer(chunk));
 						});
 
 						res.on('end',function(){


### PR DESCRIPTION
When response is chunked, node-rest-client internally calls `Buffer.concat`, which expects a list of `Buffer`s, not strings. Currently chunks are strings which triggers `undefined is not a function` error. This patch casts chunks to `Buffer`s. See also: https://github.com/feross/buffer/issues/47
