### PR TITLE
Support writing binary buffers

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -489,7 +489,9 @@ exports.Client = function (options){
 
 
 				// write POST/PUT data to request body;
-				if(options.data) request.write(typeof options.data === 'object'?JSON.stringify(options.data):options.data);
+				if(options.data) {
+					request.write(prepareData(options.data));
+				}
 
 
 				// handle request errors and handle them by request or general error handler
@@ -591,7 +593,9 @@ exports.Client = function (options){
 
 			 debug("options data", options.data);
 			// write POST/PUT data to request body;
-			if(options.data) request.write(typeof options.data === 'object'?JSON.stringify(options.data):options.data);
+			if(options.data) {
+				request.write(prepareData(options.data));
+			}
 
 			request.end();
 			 
@@ -614,4 +618,9 @@ exports.Client = function (options){
 		console.log.apply(console,args);
 
 
+	};
+	
+	var prepareData = function(data) {
+		if ((data instanceof Buffer) || (typeof data !== 'object')) return data;
+		else return JSON.stringify(data);
 	};


### PR DESCRIPTION
Existing implementation performs stringification on anything that is an object, including binary Buffers although Node Http/Https allow writing Buffers directly. Without this change it is impossible to write binary data for multipart POST requests.