### PR TITLE
Use visionmedia's debug utility

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -375,7 +375,7 @@ exports.Client = function (options){
 		},
 		"handleEnd":function(res,buffer,callback){
 			
-			self = this;
+			this.self = this;
 
 			var content = res.headers["content-type"];
 			var encoding = res.headers["content-encoding"];
@@ -428,8 +428,8 @@ exports.Client = function (options){
 			debug("proxy options",options.proxy);
 			
 			// creare a new proxy tunnel, and use to connect to API URL
-			var proxyTunnel = http.request(options.proxy),
-				self = this;
+			var proxyTunnel = http.request(options.proxy);
+			this.self = this;
 		
 			
 			proxyTunnel.on('connect',function(res, socket, head){
@@ -527,7 +527,7 @@ exports.Client = function (options){
 				clientRequest = options.clientRequest,
 				requestConfig = options.requestConfig,
 				responseConfig = options.responseConfig,
-				self = this;
+				this.self = this;
 				
 				//remove "protocol" and "clientRequest" option from options, cos is not allowed by http/hppts node objects
 				delete options.protocol;

--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -1,5 +1,7 @@
+'use strict';
 var http = require('http'),
 	https = require('https'),
+  debug = require('debug')('node-rest-client'),
 	parseString = require('xml2js').parseString,
 	urlParser = require('url'),
 	util = require("util"),
@@ -34,11 +36,11 @@ exports.Client = function (options){
 	
 
 	ClientRequest.prototype.end = function(){
-		_httpRequest.end();
+		this._httpRequest.end();
 	};
 
 	ClientRequest.prototype.setHttpRequest=function(req){
-		_httpRequest = req;
+		this._httpRequest = req;
 	};
 
 	var Util = {
@@ -604,7 +606,7 @@ exports.Client = function (options){
 	util._extend(ConnectManager,events.EventEmitter.prototype);
 
 
-	var debug = function(){
+/*	var debug = function(){
 		if (!process.env.DEBUG) return;
 
 		var now = new Date(),
@@ -615,3 +617,4 @@ exports.Client = function (options){
 
 
 	};
+*/

--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -375,7 +375,7 @@ exports.Client = function (options){
 		},
 		"handleEnd":function(res,buffer,callback){
 			
-			this.self = this;
+			var self = this;
 
 			var content = res.headers["content-type"];
 			var encoding = res.headers["content-encoding"];
@@ -429,7 +429,7 @@ exports.Client = function (options){
 			
 			// creare a new proxy tunnel, and use to connect to API URL
 			var proxyTunnel = http.request(options.proxy);
-			this.self = this;
+			var self = this;
 		
 			
 			proxyTunnel.on('connect',function(res, socket, head){
@@ -527,7 +527,7 @@ exports.Client = function (options){
 				clientRequest = options.clientRequest,
 				requestConfig = options.requestConfig,
 				responseConfig = options.responseConfig,
-				this.self = this;
+				self = this;
 				
 				//remove "protocol" and "clientRequest" option from options, cos is not allowed by http/hppts node objects
 				delete options.protocol;

--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -604,17 +604,3 @@ exports.Client = function (options){
 	// event handlers for client and ConnectManager
 	util.inherits(exports.Client, events.EventEmitter);
 	util._extend(ConnectManager,events.EventEmitter.prototype);
-
-
-/*	var debug = function(){
-		if (!process.env.DEBUG) return;
-
-		var now = new Date(),
-			header =now.getHours() + ":" + now.getMinutes() + ":" + now.getSeconds() +  " [NRC CLIENT]" + arguments.callee.caller.name + " -> ",
-			args = Array.prototype.slice.call(arguments);
-		args.splice(0,0,header);
-		console.log.apply(console,args);
-
-
-	};
-*/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "main": "./lib/node-rest-client", 
   "dependencies": {
-    "xml2js":">=0.2.4"
+    "xml2js":">=0.2.4",
+    "debug": "~2.0.0"
     },
   "devDependencies": {
     "jasmine-node":">=1.2.3"


### PR DESCRIPTION
Original implementation was using custom debug function.
When used with visionmedia's implementation in other modules, defining environment variable DEBUG to something different from empty, the custom implementation was always pushing all the debug info without option to filter it out when needed.
In this new way, you can still see conveniently all debug info if you add to DEBUG variable "node-rest-client" or "*" as visionmedia's doc states.
https://github.com/visionmedia/debug

Also added the 'use strict' string to the beginning and fixed a possible involuntary global variable definition of _httpRequest.

Thanks for the module!