### PR TITLE
fixing syntax in req.on examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -279,17 +279,17 @@ var req = client.post("http://remote.site/rest/xml/${id}/method?arg1=hello&arg2=
 });
 
 req.on('requestTimeout',function(req){
-	console.log("request has expired");
+	console.log('request has expired');
 	req.abort();
 });
 
 req.on('responseTimeout',function(res){
-	console.log("response has expired");
+	console.log('response has expired');
 	
 });
 
 //it's usefull to handle request errors to avoid, for example, socket hang up errors on request timeouts
-req.on('error'function(err){
+req.on('error', function(err){
 	console.log('request error',err);
 });
 


### PR DESCRIPTION
There was a missing comma in one of the listener examples. Also swapped double quotes for single, just within this section.