### PR TITLE
Changed debug to use node debug library

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -4,8 +4,8 @@ var http = require('http'),
 	urlParser = require('url'),
 	util = require("util"),
 	events = require("events"),
-	zlib = require("zlib");
-
+	zlib = require("zlib"),
+	node_debug = require("debug")("NRC");
 
 exports.Client = function (options){
 	var self = this;
@@ -620,7 +620,7 @@ exports.Client = function (options){
 			header =now.getHours() + ":" + now.getMinutes() + ":" + now.getSeconds() +  " [NRC CLIENT]" + arguments.callee.caller.name + " -> ",
 			args = Array.prototype.slice.call(arguments);
 		args.splice(0,0,header);
-		console.log.apply(console,args);
+		node_debug.apply(console,args);
 
 
 	};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "main": "./lib/node-rest-client", 
   "dependencies": {
-    "xml2js":">=0.2.4"
+    "xml2js":">=0.2.4",
+    "debug": "~2.1.1"
     },
   "devDependencies": {
     "jasmine-node":">=1.2.3"


### PR DESCRIPTION
Changed original debug code to use node debug library to make debugging more consistent than primitive checking of DEBUG environment variable check. Resolves #65.