### PR TITLE
bugfix: _http variable leacking into global object

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -26,7 +26,6 @@ exports.Client = function (options){
 	// for each REST method invocation
 	var ClientRequest =function(){
 		events.EventEmitter.call(this);
-		var _httpRequest;
 	};
 
 
@@ -34,11 +33,13 @@ exports.Client = function (options){
 	
 
 	ClientRequest.prototype.end = function(){
-		_httpRequest.end();
+		if(this._httpRequest) {
+			this._httpRequest.end();
+		}
 	};
 
 	ClientRequest.prototype.setHttpRequest=function(req){
-		_httpRequest = req;
+		this._httpRequest = req;
 	};
 
 	var Util = {


### PR DESCRIPTION
the name of the leaking variable is '_httpRequest'