### PR TITLE
change test for json|xml to use regex, allow spaces in header value

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -329,29 +329,13 @@ exports.Client = function (options){
 
 
 	var ConnectManager = {
-		"xmlctype":["application/xml","application/xml;charset=utf-8"],
-		"jsonctype":["application/json","application/json;charset=utf-8"],
+		"xmlctype": /application\/xml;[\s]*(charset=utf-8)?/,
+		"jsonctype": /application\/json;[\s]*(charset=utf-8)?/,
 		"isXML":function(content){
-			var result = false;
-			if (!content) return result;
-
-			for (var i=0; i<this.xmlctype.length;i++){
-				result = this.xmlctype[i].toLowerCase() === content.toLowerCase();
-				if (result) break;
-			}
-			
-			return result;
+			return this.xmlctype.test(content.toLowerCase());
 		},
 		"isJSON":function(content){
-			var result = false;
-			if (!content) return result;
-
-			for (var i=0; i<this.jsonctype.length;i++){
-				result = this.jsonctype[i].toLowerCase() === content.toLowerCase();
-				if (result) break;
-			}
-			
-			return result;
+			return this.jsonctype.test(content.toLowerCase());
 		},
 		"isValidData":function(data){
 			return data !== undefined && (data.length !== undefined && data.length > 0);


### PR DESCRIPTION
This changes the test for content-type(s) to use a regex.  This allow for spaces in content-type header to be correctly detected for json or xml types:

application/json;charset=utf-8
application/json; charset=utf-8
-------------------^-----------------