### PR TITLE
No longer deleting all headers in connect(). Fixes issue #76

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -190,6 +190,9 @@ exports.Client = function (options){
 			var options = this.createConnectOptions(this.parsePathParameters(args,url), method);
 			options.method = method;
 			options.clientRequest = clientRequest;
+            if (!options.headers) {
+                options.headers = {};
+            }
 			debug("options pre connect",options);
 			debug("args = ", args);
 			debug("args.data = ", args !== undefined?args.data:undefined);

--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -188,9 +188,8 @@ exports.Client = function (options){
 		connect : function(method, url, args, callback, clientRequest){
 			// configure connect options based on url parameter parse
 			var options = this.createConnectOptions(this.parsePathParameters(args,url), method);
-			options.method = method,
+			options.method = method;
 			options.clientRequest = clientRequest;
-			options.headers={};
 			debug("options pre connect",options);
 			debug("args = ", args);
 			debug("args.data = ", args !== undefined?args.data:undefined);


### PR DESCRIPTION
No longer deleting all headers in the connect() function.

This fixes issue #76.