### PR TITLE
Better auto parse of XML and JSON response bodies

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -335,8 +335,8 @@ exports.Client = function (options){
 
 
 	var ConnectManager = {
-		"xmlctype":["application/xml","application/xml;charset=utf-8"],
-		"jsonctype":["application/json","application/json;charset=utf-8"],
+		"xmlctype":["application/xml","application/xml;charset=utf-8","application/xml; charset=utf-8"],
+		"jsonctype":["application/json","application/json;charset=utf-8","application/json; charset=utf-8"],
 		"isXML":function(content){
 			var result = false;
 			if (!content) return result;


### PR DESCRIPTION
Some servers send Content-Type header with a space between the mime type and the charset declaration. When that happens, the body isn't automatically parsed. 

This fixes the issue.