### PR TITLE
Removed spaces from content-type headers

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -411,7 +411,7 @@ exports.Client = function (options){
 			}
 		},
 		"handleResponse":function(res,data,callback){
-			var content = res.headers["content-type"];
+			var content = res.headers["content-type"].replace(/ /g, '');
 
 			debug("response content is ",content);
 			// XML data need to be parsed as JS object

--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -411,7 +411,7 @@ exports.Client = function (options){
 			}
 		},
 		"handleResponse":function(res,data,callback){
-			var content = res.headers["content-type"].replace(/ /g, '');
+			var content = res.headers["content-type"] && res.headers["content-type"].replace(/ /g, '');
 
 			debug("response content is ",content);
 			// XML data need to be parsed as JS object

--- a/test/test-servers.js
+++ b/test/test-servers.js
@@ -49,6 +49,12 @@ var RouteManager ={
 			"/xml/empty":function(req,res){
 				res.writeHead(204, {'Content-Type': 'application/xml'});
 				res.end();
+			},
+			"/json/contenttypewithspace":function(req,res){
+				var message = fs.readFileSync('./message.json','utf8');
+				res.writeHead(200, {'Content-Type': 'application/json; charset=utf-8'});
+				res.write(message.toString());
+				res.end();
 			}
 	},
 	"sleep":function(ms){


### PR DESCRIPTION
Default content-type headers are defined without spaces.

```javascript
"jsonctype":["application/json","application/json;charset=utf-8"]
```
ElasticSearch produce response headers like `"application/json; charset=UTF-8"`
I assume that ElasticSearch is not the only product to insert a space when specifying a charset encoding.

I think it would be easier to deal with removing spaces than to define specific mimetypes for each REST endpoint.

It was a bit tricky to understand why I had a Buffer as a response instead of a JSON object.
`application/json;charset=utf-8` vs `application/json; charset=UTF-8`

