### PR TITLE
Adds additional content-type formats

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -335,8 +335,8 @@ exports.Client = function (options){
 
 
 	var ConnectManager = {
-		"xmlctype":["application/xml","application/xml;charset=utf-8"],
-		"jsonctype":["application/json","application/json;charset=utf-8"],
+		"xmlctype":["application/xml","application/xml;charset=utf-8","application/xml; charset=utf-8"],
+		"jsonctype":["application/json","application/json;charset=utf-8","application/json; charset=utf-8"],
 		"isXML":function(content){
 			var result = false;
 			if (!content) return result;


### PR DESCRIPTION
A space separating content-type and charset is allowed according to
W3 specs[1]. This space is inserted by (among others) strongloop/Express
when it outputs JSON.

[1] http://www.w3.org/International/O-HTTP-charset