### PR TITLE
Update node-rest-client.js

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -336,7 +336,7 @@ exports.Client = function (options){
 
 	var ConnectManager = {
 		"xmlctype":["application/xml","application/xml;charset=utf-8"],
-		"jsonctype":["application/json","application/json;charset=utf-8"],
+		"jsonctype":["application/json","application/json;charset=utf-8", "application/json; charset=utf-8"],
 		"isXML":function(content){
 			var result = false;
 			if (!content) return result;


### PR DESCRIPTION
Adding a new jsonctype. Some api's respond with a content type of "application/json; charset=utf-8" in which case the JSON body will not be parsed as JSON.