### PR TITLE
 Fix encodeQueryFromArgs to handle arrays as parameters in the query

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -146,10 +146,21 @@ exports.Client = function (options){
 		encodeQueryFromArgs: function(args){
 			var result="?", counter = 1;
 			// create enconded URL from args
-			for (var key in args){
-				var keyValue = key + "=" + encodeURIComponent(args[key]);
-				if (counter > 1) keyValue = '&'.concat(keyValue);
-				result = result.concat(keyValue);
+			for (var key in args) {
+				var keyValue = "";
+				if ( args[key] instanceof Array )  { 
+					/* 
+					 * We are dealing with an array in the query string  ?key=Value0&key=Value1 
+					 * That a REST application translates into key=[Value0, Value1]
+					 */
+					for ( var ii=0, sizeArray = args[key].length; ii < sizeArray; ii++ ) {
+						result = result.concat((counter > 1 ? "&": "") + key + "=" + encodeURIComponent(args[key][ii]));
+						counter++;
+					}
+				} else { //No array, just a single &key=value
+				   keyValue = key + "=" + encodeURIComponent(args[key]);
+				   result = result.concat((counter > 1 ? "&":"") + keyValue);
+				}
 				
 				counter++;
 			}


### PR DESCRIPTION
 Great module BTW, while working with a REST API that requieres sending and array in order to send the conditions for a query to retrieve data I bump into the issue that whet using the notation
condition=position|equals|boss&condition=process|equals|new during the POST only the first condition was being sent, that's how I got to work on encodeQueryFromArgs, seems to be working although I read that different http stacks handle passing arrays in multiple ways. I hope this helps.