### PR TITLE
The header content contains invalid characters

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -218,7 +218,9 @@ exports.Client = function (options){
 				// with request, but without deleting other headers like non-tunnel proxy headers
 				if (args.headers){
 					for (var headerName in args.headers){
-						options.headers[headerName] = args.headers[headerName];	
+						if (args.headers.hasOwnProperty(headerName)) {
+    							options.headers[headerName] = args.headers[headerName];	
+						}
 					}
 							
 				}


### PR DESCRIPTION
call hasOwnProperty in forin loop
fixing 'The header content contains invalid characters' error