### PR TITLE
Added generic request function with custom method param

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -293,6 +293,11 @@ exports.Client = function (options){
 
 
 
+	this.request = function(method, url, args, callback){
+		var clientRequest = new ClientRequest();		
+		Util.connect(method, url, args, callback, clientRequest);
+		return clientRequest;
+	};
 
 	this.get = function(url, args, callback){
 		var clientRequest = new ClientRequest();		


### PR DESCRIPTION
I'm moving over from Restler to this, and needed an analog for https://github.com/danwrong/restler/blob/master/README.md#requesturl-options where I could programmatically set the HTTP method.

Couldn't find anything in the issues/PRs about why something similar hadn't been implemented yet, and it seems a little weird to have skipped over it. If there's any concerns about including this or you want anything else form me, let me know.

Should also resolve #102.
