### PR TITLE
Feature : .npmignore - Ignore all debug/test-related files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+debug.bat
+debug.sh
+test/
+test.bat
+test.sh
+


### PR DESCRIPTION
The currently published version of this package (_3.1.0_) might contain some content that won't be used in production (like debug and test-related files).

Here's the list :

```
debug.bat
debug.sh
test/
test.bat
test.sh
```

![node-rest-client](https://user-images.githubusercontent.com/6564012/32663093-078dc4a6-c62d-11e7-967a-2c3f5a669ca3.png)

This PR just adds a `.npmignore` file that will prevent the publisher of the package to push files that are not needed when downloaded through npm.

Henceforth, the package will also be slightly lighter and the people who download it won't request unnecessary files :-)