### PR TITLE
add maxBodyLength to enable parameter config

### DIFF
--- a/lib/node-rest-client.js
+++ b/lib/node-rest-client.js
@@ -486,7 +486,7 @@ var ConnectManager = function(client, parserManager) {
     };
 
     this.configureOptions = function(options){
-        var followRedirectsProps =["followRedirects", "maxRedirects"];
+        var followRedirectsProps =["followRedirects", "maxRedirects", "maxBodyLength"];
         function configureProps(propsArray, optionsElement){
             for (var index in propsArray){
                 if (optionsElement.hasOwnProperty(propsArray[index]))


### PR DESCRIPTION
By adding the item to that array it is possible to configure maxBodyLength. Sometimes is needed to transfer a file as a base64 parameter and 10mb may not be enough.

Now would be possible to configurate by passing
```
          requestConfig: {
            maxBodyLength: 50 * 1024 * 1024
          }
```

to args to the request. This would enable 50mb body request.