### PR TITLE
Remove possible Unicode BOM from JSON data

### DIFF
--- a/lib/nrc-parser-manager.js
+++ b/lib/nrc-parser-manager.js
@@ -131,6 +131,15 @@ parserManager.add(Object.assign({
 		var jsonData,
 		data = byteBuffer.toString();
 
+		// Remove possible byte order marks for UTF-8/16/32.
+		// For more infos see:
+		// https://de.wikipedia.org/wiki/Byte_Order_Mark
+		// https://tools.ietf.org/html/rfc7159#section-8.1
+		var bom = [ 0xEFBB, 0xFEFF, 0xFFFE, 0x0000 ];
+		if (bom.includes(data.charCodeAt(0))) {
+			data = data.slice(1)
+		}
+
 		try {
 			jsonData = this.isValidData(data)?JSON.parse(data):data;
 		} catch (err) {


### PR DESCRIPTION
Sometimes, services send JSON data which includes a BOM (https://de.wikipedia.org/wiki/Byte_Order_Mark) which is wrong (according to https://tools.ietf.org/html/rfc7159#section-8.1 second paragraph) but break things as node-rest-client throws an exception when calling JSON.parse. This patch tries to remove UTF-8/16/32 BOMs before this to be more robust against such services.